### PR TITLE
Feat/items

### DIFF
--- a/adventure/api.py
+++ b/adventure/api.py
@@ -90,11 +90,10 @@ def interact(request):
     room = player.room()
     room_id = room.id
     # * object from POST request body
-    data = json.loads(request.body)
+    # data = json.loads(request.body)
     # * value of specified key in data from POST request body
-    command = data['command']
+    command = request.data['command']
     # * Assumes a player provies an item_id in POST request body
-    item_id = data['item_id']
     # * Additionally, assume items() method on room class to return a list of items in a room
     inventory = player.inventory()
     contents = room.contents()
@@ -110,6 +109,7 @@ def interact(request):
     if command == 'g':
         # * Retrieve id for item to grab
 
+        item_id = request.data['item_id']
         item = next(
             (item for item in contents if item['id'] == item_id), None)
         item.currentPosessor = player_id
@@ -121,6 +121,7 @@ def interact(request):
         })
     if command == 'd':
         # * Dropping will set the item's currentPossessor field to the id of the room.
+        item_id = request.data['item_id']
         item = next(
             (item for item in inventory if item['id'] == item_id), None)
         item = None

--- a/adventure/api.py
+++ b/adventure/api.py
@@ -95,14 +95,14 @@ def interact(request):
     command = request.data['command']
     # * Assumes a player provies an item_id in POST request body
     # * Additionally, assume items() method on room class to return a list of items in a room
-    inventory = player.inventory()
-    contents = room.contents()
+    # inventory = player.inventory()
+    # contents = room.contents()
 
     # * If player users 'inspect' command, return a list of the items contained in the room
     if command == 'i':
         return JsonResponse({
-            'contents': contents,
-            'inventory': inventory
+            'contents': list(room.contents()),
+            'inventory': list(player.inventory())
         })
 
     # * If player uses a 'grab' command, pick up item by updating the item's currentPossessor field
@@ -110,27 +110,24 @@ def interact(request):
         # * Retrieve id for item to grab
 
         item_id = request.data['item_id']
-        item = next(
-            (item for item in contents if item['id'] == item_id), None)
-        item.currentPosessor = player_id
+        # item = next(
+        #     (item for item in contents if item['uuid'] == item_id), None)
+        item = Item.objects.get(uuid=item_id)
+        item.currentPossessor = player.uuid
         item.save()
         return JsonResponse({
-            'name': player.user.username,
-            'inventory': player.inventory,
-            'contents': room.contents
+            'contents': list(room.contents()),
+            'inventory': list(player.inventory())
         })
     if command == 'd':
         # * Dropping will set the item's currentPossessor field to the id of the room.
         item_id = request.data['item_id']
-        item = next(
-            (item for item in inventory if item['id'] == item_id), None)
-        item = None
-        item.currentPossessor = room_id
+        item = Item.objects.get(uuid=item_id)
+        item.currentPossessor = room.uuid
         item.save()
         return JsonResponse({
-            'name': player.user.username,
-            'inventory': player.inventory,
-            'contents': room.contents
+            'contents': list(room.contents()),
+            'inventory': list(player.inventory())
         })
 
 

--- a/adventure/api.py
+++ b/adventure/api.py
@@ -89,29 +89,18 @@ def interact(request):
     player_uuid = player.uuid
     room = player.room()
     room_id = room.id
-    # * object from POST request body
-    # data = json.loads(request.body)
-    # * value of specified key in data from POST request body
-    command = request.data['command']
-    # * Assumes a player provies an item_id in POST request body
-    # * Additionally, assume items() method on room class to return a list of items in a room
-    # inventory = player.inventory()
-    # contents = room.contents()
 
-    # * If player users 'inspect' command, return a list of the items contained in the room
+    command = request.data['command']
+# * 'inspect' command returns user's inventory and current room's contents
     if command == 'i':
         return JsonResponse({
             'contents': list(room.contents()),
             'inventory': list(player.inventory())
         })
 
-    # * If player uses a 'grab' command, pick up item by updating the item's currentPossessor field
+    # * If player uses a 'grab' command, pick up item by updating the item's currentPossessor field to that user's uuid
     if command == 'g':
-        # * Retrieve id for item to grab
-
         item_id = request.data['item_id']
-        # item = next(
-        #     (item for item in contents if item['uuid'] == item_id), None)
         item = Item.objects.get(uuid=item_id)
         item.currentPossessor = player.uuid
         item.save()
@@ -119,8 +108,8 @@ def interact(request):
             'contents': list(room.contents()),
             'inventory': list(player.inventory())
         })
+        # * If player uses a 'drop' command, pick up item by updating the item's currentPossessor field to that user's uuid
     if command == 'd':
-        # * Dropping will set the item's currentPossessor field to the id of the room.
         item_id = request.data['item_id']
         item = Item.objects.get(uuid=item_id)
         item.currentPossessor = room.uuid

--- a/adventure/management/commands/item_generation.py
+++ b/adventure/management/commands/item_generation.py
@@ -34,7 +34,7 @@ adjectives = [
 
 
 def populate_items(items_count):
-    room_uuids = [room.id for room in Room.objects.all()]
+    room_uuids = [room.uuid for room in Room.objects.all()]
     items_populated = 0
 
     while items_populated < items_count:

--- a/adventure/management/commands/item_generation.py
+++ b/adventure/management/commands/item_generation.py
@@ -34,12 +34,12 @@ adjectives = [
 
 
 def populate_items(items_count):
-    room_ids = [room.id for room in Room.objects.all()]
+    room_uuids = [room.id for room in Room.objects.all()]
     items_populated = 0
 
     while items_populated < items_count:
         new_item = Item(base=f'{random.choice(adjectives)} {random.choice(base_names)}',
-                        currentPossessor=random.choice(room_ids))
+                        currentPossessor=random.choice(room_uuids))
         items_populated += 1
         new_item.save()
         # print(

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -88,7 +88,7 @@ class Player(models.Model):
 
 class Item(models.Model):
     base = models.CharField(max_length=128)
-    # * Possessor is either a room_id or a user_id -- depending on what object 'owns' the item
+    # * Possessor is either a uuid of a room or user -- depending on what object 'owns' the item
     currentPossessor = models.CharField(max_length=128)
     uuid = models.UUIDField(default=uuid.uuid4, unique=True)
 

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -24,6 +24,7 @@ class Room(models.Model):
     y_cor = models.IntegerField(default=0)
     max_exits = models.IntegerField(default=3)
     current_exits = models.IntegerField(default=0)
+    uuid = models.UUIDField(default=uuid.uuid4, unique=True)
 
     def connectRooms(self, destination_room, direction):
         opposite = {

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -89,7 +89,7 @@ class Player(models.Model):
 class Item(models.Model):
     base = models.CharField(max_length=128)
     # * Possessor is either a room_id or a user_id -- depending on what object 'owns' the item
-    currentPossessor = models.CharField()
+    currentPossessor = models.CharField(max_length=128)
     uuid = models.UUIDField(default=uuid.uuid4, unique=True)
 
 

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -58,7 +58,9 @@ class Room(models.Model):
 
     # * Returns a list of dicts containing id and name for all objects in that room
     def contents(self):
-        return [{item.name, item.currentPossessor, item.uuid} for item in Item.objects.filter(currentRoom=self.uuid)]
+        # return [{item.name, item.currentPossessor, item.uuid} for item in Item.objects.filter(currentRoom=self.uuid)]
+        print(f'self.uuid = {self.uuid}')
+        return Item.objects.filter(currentPossessor=self.uuid).values()
 
 
 class Player(models.Model):
@@ -80,13 +82,14 @@ class Player(models.Model):
 
     # * Returns a list of all objects whose current_id matches the player's user_id
     def inventory(self):
-        return Item.objects.get(currentPossessor=self.uuid)
+        print(f'self.uuid = {self.uuid}')
+        return Item.objects.filter(currentPossessor=self.uuid).values()
 
 
 class Item(models.Model):
     base = models.CharField(max_length=128)
     # * Possessor is either a room_id or a user_id -- depending on what object 'owns' the item
-    currentPossessor = models.IntegerField()
+    currentPossessor = models.CharField()
     uuid = models.UUIDField(default=uuid.uuid4, unique=True)
 
 

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -58,7 +58,7 @@ class Room(models.Model):
 
     # * Returns a list of dicts containing id and name for all objects in that room
     def contents(self):
-        return [{item.name, item.currentPossessor, item.uuid} for item in Item.objects.filter(currentRoom=self.id)]
+        return [{item.name, item.currentPossessor, item.uuid} for item in Item.objects.filter(currentRoom=self.uuid)]
 
 
 class Player(models.Model):
@@ -80,7 +80,7 @@ class Player(models.Model):
 
     # * Returns a list of all objects whose current_id matches the player's user_id
     def inventory(self):
-        return Item.objects.get(currentPossessor=self.id)
+        return Item.objects.get(currentPossessor=self.uuid)
 
 
 class Item(models.Model):

--- a/adventure/models.py
+++ b/adventure/models.py
@@ -86,7 +86,7 @@ class Player(models.Model):
 class Item(models.Model):
     base = models.CharField(max_length=128)
     # * Possessor is either a room_id or a user_id -- depending on what object 'owns' the item
-    currentPossessor = models.IntegerField(default=0)
+    currentPossessor = models.IntegerField()
     uuid = models.UUIDField(default=uuid.uuid4, unique=True)
 
 


### PR DESCRIPTION
# Description
Introduces ability for user to inspect a room for its contents, and grab or add an item.

The endpoint to inspect a room, grab items, and drop items is `api/adv/interact`.

To inspect a room, make POST request to the endpoint with a body of the following shape:
`{"command": "i"}`

This will return a list of the room's contents and a list of the user's inventory.
```{
  "contents": [
    {
      "id": 517,
      "base": "Broken Dagger",
      "currentPossessor": "23b14331-1863-40bc-aba9-f41d112d50f3",
      "uuid": "919f27cf-d432-4129-a6d6-e697e5408119"
    },
    {
      "id": 522,
      "base": "Cryptic Apple",
      "currentPossessor": "23b14331-1863-40bc-aba9-f41d112d50f3",
      "uuid": "60391a9a-84ec-4da7-a83d-9020fd9b8cca"
    },
    {
      "id": 596,
      "base": "Enchanted Cloak",
      "currentPossessor": "23b14331-1863-40bc-aba9-f41d112d50f3",
      "uuid": "68e23467-f524-4065-bb67-3289dfc358da"
    }
  ],
  "inventory": []
}
```

To grab an item, provide the command 'g' and the item's uuid. Currently only one item at a time may be picked up and added to the user's inventory.
`{"command": "g",
"item": "60391a9a-84ec-4da7-a83d-9020fd9b8cca"
}`
This will return updated lists of both the room's contents and the user's inventory.

To drop an item, provide the command 'd' and the item's uuid. Currently only one item at a time can be dropped into the room's contents.
`{"command": "g",
"item": "60391a9a-84ec-4da7-a83d-9020fd9b8cca"
}`

This will return updated lists of both the room's contents and the user's inventory.

There is currently no error handling for cases in which a user attempts to drop or grab an item that has already had the respective action performed.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge


